### PR TITLE
add slow tests, separate import validation, and strip builds from exported file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,45 @@ jobs:
           python-version: ${{ matrix.python }}.*
           auto-update-conda: true
           use-only-tar-bz2: true
+  validate:
+    name: run import tests (Python ${{ matrix.python }}, ${{ matrix.os }})
+    needs: [ build ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python: [ '3.8', '3.9', '3.10' ]
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - if: runner.os == 'Linux'
+        run: |
+          echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
+          echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
+          sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+      - if: runner.os == 'MacOS'
+        run: |
+          echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
+          echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
+          sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+      - run: |
+          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
+          echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
+      - run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        id: date
+      - uses: actions/cache@v3.0.5
+        with:
+          path: |
+            ${{ env.HOME }}/conda_pkgs_dir
+            ${{ env.CONDA }}/envs/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest
+          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ steps.date.outputs.date }}
+      - uses: conda-incubator/setup-miniconda@v2.1.1
+        with:
+          activate-environment: spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest
+          environment-file: spacetelescope-env-latest.yml
+          python-version: ${{ matrix.python }}.*
+          auto-update-conda: true
+          use-only-tar-bz2: true
       - run: conda install -y pytest pytest-xdist
       - run: pytest -n auto tests/test_import.py
       - run: conda env export > spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
@@ -68,7 +107,7 @@ jobs:
           path: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
   unit_tests:
     name: run `${{ matrix.package }}` unit tests (Python ${{ matrix.python }}, ${{ matrix.os }})
-    needs: [ build ]
+    needs: [ validate ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -78,14 +117,14 @@ jobs:
         package: [ acstools, ccdproc, costools, jwst, reftools, synphot, wfpc2tools ]
         include:
           - package: acstools
-            dependencies: [ ci-watson, pytest-astropy-header, pytest-remotedata ]
+            dependencies: [ pytest-astropy-header, pytest-remotedata ]
           - package: ccdproc
             dependencies: [ memory_profiler, pytest-astropy ]
           - package: costools
           #- package: crds
           #  dependencies: [ lockfile, mock, nose, pylint ]
           - package: jwst
-            dependencies: [ ci-watson, pytest-doctestplus, pytest-openfiles, requests_mock ]
+            dependencies: [ pytest-doctestplus, pytest-openfiles, requests_mock ]
             CRDS_SERVER_URL: https://jwst-crds.stsci.edu
           #- package: nictools
           #- package: pysynphot
@@ -128,8 +167,7 @@ jobs:
           auto-update-conda: true
           use-only-tar-bz2: true
       - run: conda install -y pytest pytest-xdist
-      - run: pip install ${{ join(matrix.dependencies, ' ') }}
-        if: matrix.dependencies != ''
+      - run: pip install ci-watson ${{ join(matrix.dependencies, ' ') }}
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
@@ -146,14 +184,14 @@ jobs:
         env:
           CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
-      - run: pytest -n auto ${{ matrix.pytest_args }} --pyargs ${{ matrix.package }}
+      - run: pytest -n auto --slow ${{ matrix.pytest_args }} --pyargs ${{ matrix.package }}
         env:
           PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
           CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
   unit_tests_from_source:
     name: run `${{ matrix.package }}` unit tests (Python ${{ matrix.python }}, ${{ matrix.os }}) from source
-    needs: [ build ]
+    needs: [ validate ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -164,13 +202,11 @@ jobs:
         include:
           - package: calcos
             repository: spacetelescope/calcos
-            dependencies: [ ci_watson ]
           #- package: drizzlepac
           #  repository: spacetelescope/drizzlepac
-          #  dependencies: [ ci-watson, crds, pytest-remotedata ]
+          #  dependencies: [ crds, pytest-remotedata ]
           - package: hstcal
             repository: spacetelescope/hstcal
-            dependencies: [ ci-watson ]
             test_directory: tests
             CRDS_SERVER_URL: https://hst-crds.stsci.edu
           #- package: stistools
@@ -178,7 +214,7 @@ jobs:
           #  dependencies: [ six ]
           - package: stsynphot
             repository: spacetelescope/stsynphot_refactor
-            dependencies: [ ci-watson, pytest-astropy ]
+            dependencies: [ pytest-astropy ]
     steps:
       - uses: actions/checkout@v3.0.2
         with:
@@ -219,8 +255,7 @@ jobs:
           repository: ${{ matrix.repository }}
           ref: ${{ steps.version.outputs.version }}
       - run: cd ${{ matrix.package }} && conda install -y pytest pytest-xdist
-      - run: cd ${{ matrix.package }} && pip install ${{ join(matrix.dependencies, ' ') }}
-        if: matrix.dependencies != ''
+      - run: cd ${{ matrix.package }} && pip install ci-watson ${{ join(matrix.dependencies, ' ') }}
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
@@ -237,14 +272,14 @@ jobs:
         env:
           CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
-      - run: cd ${{ matrix.package }} && pytest -n auto ${{ matrix.pytest_args }} ${{ matrix.test_directory }}
+      - run: cd ${{ matrix.package }} && pytest -n auto --slow ${{ matrix.pytest_args }} ${{ matrix.test_directory }}
         env:
           PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
           CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
   smoke_tests:
     name: run `${{ matrix.package }}` smoke tests (Python ${{ matrix.python }}, ${{ matrix.os }})
-    needs: [ build ]
+    needs: [ validate ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,8 @@ jobs:
       - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
         if: runner.os == 'MacOS'
       - run: |
-          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
+          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
       - run: echo "::set-output name=date::$(date +'%Y%m%d')"
         id: date
       - uses: actions/cache@v3.0.5
@@ -154,8 +154,8 @@ jobs:
       - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
         if: runner.os == 'MacOS'
       - run: |
-          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
+          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
       - run: echo "::set-output name=date::$(date +'%Y%m%d')"
         id: date
       - uses: actions/cache@v3.0.5
@@ -177,9 +177,9 @@ jobs:
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
-          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
+          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
       - uses: actions/cache@v3.0.5
         if: matrix.CRDS_SERVER_URL != ''
         with:
@@ -188,13 +188,13 @@ jobs:
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
         if: matrix.CRDS_SERVER_URL != ''
         env:
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
       - run: pytest -n auto --slow ${{ matrix.pytest_args }} --pyargs ${{ matrix.package }}
         env:
-          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
+          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
   unit_tests_from_source:
     name: run `${{ matrix.package }}` unit tests (Python ${{ matrix.python }}, ${{ matrix.os }}) from source
     needs: [ validate ]
@@ -238,8 +238,8 @@ jobs:
       - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-distribution/spacetelescope-env-latest.yml
         if: runner.os == 'MacOS'
       - run: |
-          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
+          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
       - run: echo "::set-output name=date::$(date +'%Y%m%d')"
         id: date
       - uses: actions/cache@v3.0.5
@@ -268,9 +268,9 @@ jobs:
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
-          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
+          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
       - uses: actions/cache@v3.0.5
         if: matrix.CRDS_SERVER_URL != ''
         with:
@@ -279,13 +279,13 @@ jobs:
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
         if: matrix.CRDS_SERVER_URL != ''
         env:
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
       - run: cd ${{ matrix.package }} && pytest -n auto --slow ${{ matrix.pytest_args }} ${{ matrix.test_directory }}
         env:
-          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
+          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
   smoke_tests:
     name: run `${{ matrix.package }}` smoke tests (Python ${{ matrix.python }}, ${{ matrix.os }})
     needs: [ validate ]
@@ -322,8 +322,8 @@ jobs:
       - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
         if: runner.os == 'MacOS'
       - run: |
-          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
+          echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
       - run: echo "::set-output name=date::$(date +'%Y%m%d')"
         id: date
       - uses: actions/cache@v3.0.5
@@ -349,9 +349,9 @@ jobs:
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
-          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
+          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
           jref: ${{ env.CRDS_PATH }}/${{ matrix.jref }}
       - uses: actions/cache@v3.0.5
         if: matrix.CRDS_SERVER_URL != ''
@@ -361,13 +361,13 @@ jobs:
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
         if: matrix.CRDS_SERVER_URL != ''
         env:
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
       - run: ${{ matrix.run }}
         env:
-          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
-          CRDS_PATH: ${{ env.CRDS_PATH }}
           CRDS_SERVER_URL: ${{ matrix.CRDS_SERVER_URL }}
+          CRDS_PATH: ${{ env.CRDS_PATH }}
+          PYSYN_CDBS: ${{ env.PYSYN_CDBS }}
           jref: ${{ env.CRDS_PATH }}/${{ matrix.jref }}
   export:
     name: export environment (Python ${{ matrix.python }}, ${{ matrix.os }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,13 @@ name: build
 
 on:
   push:
+    branches-ignore:
+      - main
+    paths:
+      - "**/*.yml"
+  pull_request:
+    branches:
+      - main
     paths:
       - "**/*.yml"
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,18 @@ jobs:
           python-version: ${{ matrix.python }}.*
           auto-update-conda: true
           use-only-tar-bz2: true
+      - run: conda update --all
+      - run: conda env export --no-builds > spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+        if: runner.os == 'Linux'
+      - run: sed -i "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+        if: runner.os == 'Linux'
+      - run: cat spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+        if: runner.os == 'Linux'
+      - uses: actions/upload-artifact@v3.1.0
+        if: runner.os == 'Linux'
+        with:
+          name: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+          path: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
   validate:
     name: run import tests (Python ${{ matrix.python }}, ${{ matrix.os }})
     needs: [ build ]
@@ -94,17 +106,6 @@ jobs:
           use-only-tar-bz2: true
       - run: conda install -y pytest pytest-xdist
       - run: pytest -n auto tests/test_import.py
-      - run: conda env export > spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'Linux'
-      - run: sed -i "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'Linux'
-      - run: cat spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'Linux'
-      - uses: actions/upload-artifact@v3.1.0
-        if: runner.os == 'Linux'
-        with:
-          name: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-          path: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
   unit_tests:
     name: run `${{ matrix.package }}` unit tests (Python ${{ matrix.python }}, ${{ matrix.os }})
     needs: [ validate ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,17 +63,7 @@ jobs:
           auto-update-conda: true
           use-only-tar-bz2: true
       - run: conda update --all
-      - run: conda env export --no-builds > spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-      - run: sed -i "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'Linux'
-      - run: sed -i "" "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'MacOS'
-      - run: cat spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-      - uses: actions/upload-artifact@v3.1.0
-        if: runner.os == 'Linux'
-        with:
-          name: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-          path: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+      - run: conda env export
   validate:
     name: run import tests (Python ${{ matrix.python }}, ${{ matrix.os }})
     needs: [ build ]
@@ -116,6 +106,7 @@ jobs:
           auto-update-conda: true
           use-only-tar-bz2: true
       - run: conda install -y pytest pytest-xdist
+      - run: conda env export
       - run: pytest -n auto tests/test_import.py
   unit_tests:
     name: run `${{ matrix.package }}` unit tests (Python ${{ matrix.python }}, ${{ matrix.os }})
@@ -182,6 +173,7 @@ jobs:
           use-only-tar-bz2: true
       - run: conda install -y pytest pytest-xdist
       - run: pip install ci-watson ${{ join(matrix.dependencies, ' ') }}
+      - run: conda env export
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
@@ -272,6 +264,7 @@ jobs:
           ref: ${{ steps.version.outputs.version }}
       - run: cd ${{ matrix.package }} && conda install -y pytest pytest-xdist
       - run: cd ${{ matrix.package }} && pip install ci-watson ${{ join(matrix.dependencies, ' ') }}
+      - run: conda env export
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
@@ -352,6 +345,7 @@ jobs:
           path: 'tests/data/'
           key: data-${{ hashFiles('tests/data/*') }}
       - run: conda install -y pytest pytest-xdist
+      - run: conda env export
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.CRDS_SERVER_URL != ''
         env:
@@ -378,7 +372,6 @@ jobs:
   export:
     name: export environment (Python ${{ matrix.python }}, ${{ matrix.os }})
     needs: [ unit_tests, unit_tests_from_source, smoke_tests ]
-    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -413,11 +406,18 @@ jobs:
           python-version: ${{ matrix.python }}.*
           auto-update-conda: true
           use-only-tar-bz2: true
-      - run: conda env export > spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'Linux'
+      - run: conda env export --no-builds > spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
       - run: sed -i "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
         if: runner.os == 'Linux'
-      - uses: svenstaro/upload-release-action@2.3.0
+      - run: sed -i "" "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+        if: runner.os == 'MacOS'
+      - run: cat spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+      - uses: actions/upload-artifact@v3.1.0
         if: runner.os == 'Linux'
+        with:
+          name: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+          path: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+      - uses: svenstaro/upload-release-action@2.3.0
+        if: github.event_name == 'release' && github.event.action == 'published' && runner.os == 'Linux'
         with:
           file: spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,18 @@ jobs:
         python: [ '3.8', '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3.0.2
-      - if: runner.os == 'Linux'
-        run: |
+      - run: |
           echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
-          sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
-      - if: runner.os == 'MacOS'
-        run: |
+        if: runner.os == 'Linux'
+      - run: |
           echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
-          sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
+      - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'Linux'
+      - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
       - uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.python }}
@@ -55,11 +57,11 @@ jobs:
           use-only-tar-bz2: true
       - run: conda update --all
       - run: conda env export --no-builds > spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'Linux'
       - run: sed -i "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
         if: runner.os == 'Linux'
+      - run: sed -i "" "s/spacetelescope-env-${{ runner.os }}-py${{ matrix.python }}-latest/spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}/g" spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
+        if: runner.os == 'MacOS'
       - run: cat spacetelescope-env-py${{ matrix.python }}-v${{ steps.version.outputs.version }}.yml
-        if: runner.os == 'Linux'
       - uses: actions/upload-artifact@v3.1.0
         if: runner.os == 'Linux'
         with:
@@ -76,16 +78,18 @@ jobs:
         python: [ '3.8', '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3.0.2
-      - if: runner.os == 'Linux'
-        run: |
+      - run: |
           echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
-          sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
-      - if: runner.os == 'MacOS'
-        run: |
+        if: runner.os == 'Linux'
+      - run: |
           echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
-          sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
+      - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'Linux'
+      - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
       - run: |
           echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
@@ -139,16 +143,18 @@ jobs:
           - package: wfpc2tools
     steps:
       - uses: actions/checkout@v3.0.2
-      - if: runner.os == 'Linux'
-        run: |
+      - run: |
           echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
-          sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
-      - if: runner.os == 'MacOS'
-        run: |
+        if: runner.os == 'Linux'
+      - run: |
           echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
-          sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
+      - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'Linux'
+      - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
       - run: |
           echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
@@ -220,16 +226,18 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           path: spacetelescope-env-distribution
-      - if: runner.os == 'Linux'
-        run: |
+      - run: |
           echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
-          sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-distribution/spacetelescope-env-latest.yml
-      - if: runner.os == 'MacOS'
-        run: |
+        if: runner.os == 'Linux'
+      - run: |
           echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
-          sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-distribution/spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
+      - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-distribution/spacetelescope-env-latest.yml
+        if: runner.os == 'Linux'
+      - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-distribution/spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
       - run: |
           echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
@@ -301,16 +309,18 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           lfs: true
-      - if: runner.os == 'Linux'
-        run: |
+      - run: |
           echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
-          sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
-      - if: runner.os == 'MacOS'
-        run: |
+        if: runner.os == 'Linux'
+      - run: |
           echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
-          sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
+      - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'Linux'
+      - run: sed -i "" "s/python==3.9/python==${{ matrix.python }}.*/g" spacetelescope-env-latest.yml
+        if: runner.os == 'MacOS'
       - run: |
           echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
@@ -370,14 +380,14 @@ jobs:
         python: [ '3.8', '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3.0.2
-      - if: runner.os == 'Linux'
-        run: |
+      - run: |
           echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
-      - if: runner.os == 'MacOS'
-        run: |
+        if: runner.os == 'Linux'
+      - run: |
           echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
           echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
+        if: runner.os == 'MacOS'
       - uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Putting the import validation step in a separate dependent job in the workflow prevents the testing packages (`pytest-xdist`, `ci-watson`, etc.) from being included in the exported environment file.