### PR TITLE
only use conda-forge-packaged `numpy` if Python is NOT free-threaded; otherwise `numpy` will force the free-threaded version and break package compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.variables.outputs.date }}
           init-shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,6 +52,7 @@ jobs:
   #           use_uv: true
   #         create-args: >-
   #           python=${{ matrix.python-version }}
+  #           ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
   #         cache-environment: true
   #         cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
   #         init-shell: bash
@@ -83,6 +84,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -124,6 +126,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -168,6 +171,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -199,6 +203,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -247,6 +252,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -299,6 +305,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -349,6 +356,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -398,6 +406,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -429,6 +438,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -460,6 +470,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -502,6 +513,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -542,6 +554,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash
@@ -573,6 +586,7 @@ jobs:
             use_uv: true
           create-args: >-
             python=${{ matrix.python-version }}
+            ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.13') && 'numpy' || '' }}
           cache-environment: true
           cache-environment-key: environment-${{ matrix.python-version }}-${{ needs.build.outputs.date }}
           init-shell: bash

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,7 +7,6 @@ channels:
 dependencies:
   - fitsverify
   - hstcal>=3.0.3
-  - numpy
   - python>=3.12
   - uv
   - pip:


### PR DESCRIPTION
fixes #250 